### PR TITLE
Upgrade Stardog to 10.1.0

### DIFF
--- a/.changeset/funny-kings-cover.md
+++ b/.changeset/funny-kings-cover.md
@@ -1,0 +1,5 @@
+---
+"stardog-docker": patch
+---
+
+Upgrade Stardog to 10.1.0 (#40)

--- a/.changeset/funny-laws-invent.md
+++ b/.changeset/funny-laws-invent.md
@@ -1,0 +1,5 @@
+---
+"stardog-docker": patch
+---
+
+Upgrade Java OpenTelemetry instrumentation agent to 2.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 docker.io/library/eclipse-temurin:11-jre-jammy
 
-ARG OTEL_VERSION="2.3.0"
+ARG OTEL_VERSION="2.4.0"
 ARG STARDOG_VERSION="10.0.1"
 
 ENV STARDOG_HOME="/var/opt/stardog"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 docker.io/library/eclipse-temurin:11-jre-jammy
 
 ARG OTEL_VERSION="2.4.0"
-ARG STARDOG_VERSION="10.0.1"
+ARG STARDOG_VERSION="10.1.0"
 
 ENV STARDOG_HOME="/var/opt/stardog"
 


### PR DESCRIPTION
This PR is doing the following:
- upgrade Stardog to 10.1.0
- upgrade Java OpenTelemetry instrumentation agent to 2.4.0

Closes #40.